### PR TITLE
feat: add CSV export option after solver execution

### DIFF
--- a/numcore_cli/formatter.py
+++ b/numcore_cli/formatter.py
@@ -8,6 +8,8 @@ from rich import box
 
 from numcore_engine.models import NumericalStep
 
+import csv
+
 
 class NumericalFormatter:
     """
@@ -19,6 +21,47 @@ class NumericalFormatter:
     # ──────────────────────────────────────────────────────────────
     # Generic fallback
     # ──────────────────────────────────────────────────────────────
+
+    @staticmethod
+    def export_steps_to_csv(steps, filename, method):
+        try:
+            if not steps:
+                print("No data to export.")
+                return
+
+            with open(filename, "w", newline="") as f:
+                writer = csv.writer(f)
+                if not filename.endswith(".csv"):
+                    filename += ".csv"
+
+                # pega todas as chaves possíveis de details
+                detail_keys = sorted({
+                    key for step in steps for key in step.details.keys()
+                })
+
+                # cabeçalho
+                headers = ["iteration", "value", "error"] + detail_keys
+                writer.writerow(headers)
+
+                # linhas
+                for step in steps:
+                    row = [
+                        step.step_idx + 1,
+                        step.value,
+                        step.error if step.error is not None else ""
+                    ]
+
+                    for key in detail_keys:
+                        val = step.details.get(key, "")
+                        row.append(val)
+
+                    writer.writerow(row)
+
+            print(f"Saved: {filename}")
+
+        except Exception as e:
+            print(f"Error saving CSV: {e}")
+
 
     @staticmethod
     def format_steps(steps: List[NumericalStep], title: Optional[str] = None) -> Table:
@@ -108,7 +151,7 @@ class NumericalFormatter:
                 f"{err:.4e}"    if err is not None          else "--",
                 Text(converging, style=status_style),
             )
-
+        
         console.print(table)
 
     # ──────────────────────────────────────────────────────────────

--- a/numcore_cli/terminal.py
+++ b/numcore_cli/terminal.py
@@ -36,6 +36,18 @@ class NumericalCLI:
         """Clear the terminal screen."""
         self.console.clear()
 
+    def ask_export(self, steps, method):
+
+        export = input("Export results to CSV? y/n [n]: ").strip().lower()
+
+        if export == "y":
+            filename = input("Enter filename [results.csv]: ").strip()
+
+            if not filename:
+                filename = "results.csv"
+
+            self.formatter.export_steps_to_csv(steps, filename, method)
+
     def display_header(self, title: str, subtitle: Optional[str] = None):
         """Display a consistent header for all screens."""
         header_text = Text()
@@ -172,6 +184,7 @@ class NumericalCLI:
                 title="Result",
                 border_style="green"
             ))
+            self.ask_export(steps, "newton")
         except Exception as e:
             self.console.print(f"[bold red]Error: {str(e)}[/bold red]")
         
@@ -222,6 +235,7 @@ class NumericalCLI:
                 title="Result",
                 border_style="green"
             ))
+            self.ask_export(steps, "simple")
         except Exception as e:
             self.console.print(f"[bold red]Error: {str(e)}[/bold red]")
         
@@ -335,6 +349,7 @@ class NumericalCLI:
                 title="Result",
                 border_style="green"
             ))
+            self.ask_export(steps, "gauss")
         except Exception as e:
             self.console.print(f"[bold red]Error: {str(e)}[/bold red]")
         
@@ -425,6 +440,7 @@ class NumericalCLI:
                 title="Result",
                 border_style="green"
             ))
+            self.ask_export(steps, "jacobi")
         except Exception as e:
             self.console.print(f"[bold red]Error: {str(e)}[/bold red]")
 
@@ -509,6 +525,7 @@ class NumericalCLI:
                 title="Result",
                 border_style="green"
             ))
+            self.ask_export(steps, "interpolation")
         except Exception as e:
             self.console.print(f"[bold red]Error: {str(e)}[/bold red]")
         
@@ -567,11 +584,11 @@ class NumericalCLI:
                 title="Result",
                 border_style="green"
             ))
+            self.ask_export(steps, "integration")
         except Exception as e:
             self.console.print(f"[bold red]Error: {str(e)}[/bold red]")
         
         Prompt.ask("\nPress Enter to return to menu")
-
 
 def launch_cli():
     """Launch the CLI application."""


### PR DESCRIPTION
## Summary
Adds an option to export iteration steps to a CSV file after solver execution.

## Changes
- Implemented export_steps_to_csv in formatter.py
- Added prompt after each solver run_* method in terminal.py
- Ensured CSV structure matches method-specific step data

## Notes
- Uses Python built-in csv module (no external dependencies)
- Handles different step structures via step.details
